### PR TITLE
Improve item styling in navigation menu

### DIFF
--- a/assets/css/css.scss
+++ b/assets/css/css.scss
@@ -167,10 +167,9 @@ div.burger {
   padding: 0;
 
   li {
-    line-height: 40px;
-    text-indent: 20px;
 
     a {
+      padding: 20px;
       color: #8e98a7;
       display: block;
       text-decoration: none;


### PR DESCRIPTION
The previous one was bit broken with multi-line items.
- Use padding in <a>'s to make them bigger and easier to interact with,
  which also takes care of separating the items from each other
- Makes also the close button to be easier to hit

Before:

![menu-before](https://cloud.githubusercontent.com/assets/101693/4216091/5829aea4-38d5-11e4-89c4-18d93d1551f0.png)

After:

![menu-after](https://cloud.githubusercontent.com/assets/101693/4216097/65f86d9a-38d5-11e4-8eb9-a4ded4f6128e.png)
