### PR TITLE
Fix internal urls to be relative to site baseurl

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+spiceprogram.org

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 markdown:      kramdown
-url: http://spiceprogram.org
+baseurl: /spiceprogram
 sass:
      style: compressed
 gems:

--- a/_includes/bottom-banner.html
+++ b/_includes/bottom-banner.html
@@ -2,7 +2,7 @@
 <div class="container" style="padding-top: 40px;">
     <div class="row">
         <div class="col-sm-8 col-sm-offset-2" style="padding: 40px; display: inline-block; z-index: 1; background-color: #f3f3f4;">
-            <a href="/why" class="pull-left">
+            <a href="{{ site.baseurl }}/why" class="pull-left">
                 <div class="col-sm-10 arrow-box">
                     <h3>Why are we doing this?</h3>
                     <p>Our company both advocates and benefits from making use of open source software when we build software ...</p>
@@ -12,23 +12,23 @@
                 </div>
             </a>
         </div>
-        <a href="/choose">
+        <a href="{{ site.baseurl }}/choose">
             <div class="col-sm-4 box brown centered">
-                <img class="small-icon" src="/assets/img/choose_big.svg" />
+                <img class="small-icon" src="{{ site.baseurl }}/assets/img/choose_big.svg" />
                 <h3>Choosing a license</h3>
                 <p>How to choose the best license for your project</p>
             </div>
         </a>
-        <a href="/licenses">
+        <a href="{{ site.baseurl }}/licenses">
             <div class="col-sm-4 box grey centered">
-                <img src="/assets/img/popular.svg" />
+                <img src="{{ site.baseurl }}/assets/img/popular.svg" />
                 <h3>Common open source licences</h3>
                 <p>Check out our summaries for the 13 most common licenses.</p>
             </div>
         </a>
-        <a href="/cc">
+        <a href="{{ site.baseurl }}/cc">
             <div class="col-sm-4 box orange centered">
-                <img src="/assets/img/cc.svg" />
+                <img src="{{ site.baseurl }}/assets/img/cc.svg" />
                 <h3>Creative commons</h3>
                 <p>What is creative commons? How can it be used?</p>
             </div>

--- a/_includes/chilicorn.md
+++ b/_includes/chilicorn.md
@@ -1,10 +1,10 @@
 "The Realm of the Chilicorn" by [ttur](https://github.com/ttur) is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
 
-There has been talk about getting some statistics out regarding our [sponsored open source contributions](/oss-sponsorship). Since I find both pie charts and the most pies disgusting, I wanted to try something different. A map! Since making one properly (automatic generation, good look and feel, maybe some interaction magic on top of it) sounds like a lot of work, a proof of concept was in order. It's lovingly drawn with the most powerful proprietary tool of them all, MS Paint.
+There has been talk about getting some statistics out regarding our [sponsored open source contributions]({{ site.baseurl }}/oss-sponsorship). Since I find both pie charts and the most pies disgusting, I wanted to try something different. A map! Since making one properly (automatic generation, good look and feel, maybe some interaction magic on top of it) sounds like a lot of work, a proof of concept was in order. It's lovingly drawn with the most powerful proprietary tool of them all, MS Paint.
 
 Our developers found it amusing, so we decided to share.
 
-You can download the original BMP from [here](/assets/img/realm-of-the-chilicorn.bmp), or a larger PNG from [here](/assets/img/realm-of-the-chilicorn.png).
+You can download the original BMP from [here]({{ site.baseurl }}/assets/img/realm-of-the-chilicorn.bmp), or a larger PNG from [here]({{ site.baseurl }}/assets/img/realm-of-the-chilicorn.png).
 
 ... the hell is a Chilicorn? 
 ----------------------------
@@ -15,7 +15,7 @@ Originally I made a version with MS Paint (you can find that below) to put press
 
 <div class="row text-center">
     <div class="col-md-8 col-md-offset-2">
-        <img class="padded-img page-img" src="/assets/img/logo/chilicorn_no_text-512.png" alt="Spice Program logo" />
+        <img class="padded-img page-img" src="{{ site.baseurl }}/assets/img/logo/chilicorn_no_text-512.png" alt="Spice Program logo" />
     </div>
 </div>
 
@@ -30,13 +30,13 @@ Here's the original MS Paint version:
 
 <div class="row text-center">
     <div class="col-md-8 col-md-offset-2">
-        <img class="padded-img page-img" src="/assets/img/chilicorn.png" alt="Chilicorn" />
+        <img class="padded-img page-img" src="{{ site.baseurl }}/assets/img/chilicorn.png" alt="Chilicorn" />
     </div>
 </div>
 
 "Chilicorn" by [ttur](https://github.com/ttur) is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
 
-Original available [here](/assets/img/chilicorn.png).
+Original available [here]({{ site.baseurl }}/assets/img/chilicorn.png).
 
 History
 -------
@@ -45,7 +45,7 @@ Here's how that came to be, summarized in one pic:
 
 <div class="row text-center">
     <div class="col-md-8 col-md-offset-2">
-        <img class="padded-img page-img" src="/assets/img/photos/chilicorn-birth.png" alt="Our new logo" />
+        <img class="padded-img page-img" src="{{ site.baseurl }}/assets/img/photos/chilicorn-birth.png" alt="Our new logo" />
     </div>
 </div>
 
@@ -55,7 +55,7 @@ That escalated quickly and in three days we had physical manifestations around t
 
 <div class="row text-center">
     <div class="col-md-8 col-md-offset-2">
-        <img class="padded-img page-img" src="/assets/img/photos/chilicorn-mug.jpg" alt="Our new logo" />
+        <img class="padded-img page-img" src="{{ site.baseurl }}/assets/img/photos/chilicorn-mug.jpg" alt="Our new logo" />
     </div>
 </div>
 
@@ -65,7 +65,7 @@ To conclude this story, here's the unofficial publishing of the new logo:
 
 <div class="row text-center">
     <div class="col-md-8 col-md-offset-2">
-        <img class="padded-img page-img" src="/assets/img/photos/logo-launch.png" alt="Logo launched" />
+        <img class="padded-img page-img" src="{{ site.baseurl }}/assets/img/photos/logo-launch.png" alt="Logo launched" />
     </div>
 </div>
 

--- a/_includes/choose.md
+++ b/_includes/choose.md
@@ -11,7 +11,7 @@ This may be a good starting point, but you really want to read a bit about the l
 
 Here's how we roll:
 
-![Choosing an open source license](/assets/img/choosinglicence.png "Choose")
+![Choosing an open source license]({{ site.baseurl }}/assets/img/choosinglicence.png "Choose")
 
 Can I use this work?
 --------------------
@@ -22,4 +22,4 @@ If you want to possibly ruin your perfectly good browsing & coffee break, [this 
 
 Again, as far as the licenses go, this should be pretty solid:
 
-![Using creative work](/assets/img/using.png "Use")
+![Using creative work]({{ site.baseurl }}/assets/img/using.png "Use")

--- a/_includes/creative-commons.md
+++ b/_includes/creative-commons.md
@@ -4,39 +4,39 @@ Organizations making use of CC licenses include Flickr, Wikipedia and Nine Inch 
 
 The parameters are:
 
-* ![Attribution CC BY](/assets/img/by.svg) Attribution (BY) - must credit the author of the original work
-* ![Attribution CC BY](/assets/img/nd.svg) No Derivatives (ND) - not allowed to modify the original work
-* ![Attribution CC BY](/assets/img/nc-eu.svg) Non Commercial (NC) - only non-commercial use and derivatives
-* ![Attribution CC BY](/assets/img/sa.svg) Share Alike (SA) - copyleft parameter, license must remain the same
+* ![Attribution CC BY]({{ site.baseurl }}/assets/img/by.svg) Attribution (BY) - must credit the author of the original work
+* ![Attribution CC BY]({{ site.baseurl }}/assets/img/nd.svg) No Derivatives (ND) - not allowed to modify the original work
+* ![Attribution CC BY]({{ site.baseurl }}/assets/img/nc-eu.svg) Non Commercial (NC) - only non-commercial use and derivatives
+* ![Attribution CC BY]({{ site.baseurl }}/assets/img/sa.svg) Share Alike (SA) - copyleft parameter, license must remain the same
 
 These four parameters are used to define a total of six different licenses:
 
-[![Attribution CC BY](/assets/img/by.svg)](http://creativecommons.org/licenses/by/4.0/)
+[![Attribution CC BY]({{ site.baseurl }}/assets/img/by.svg)](http://creativecommons.org/licenses/by/4.0/)
 
 Attribution CC BY
 -----------------
 
 This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of licenses offered. Recommended for maximum dissemination and use of licensed materials.
 
-[![Attribution-NoDerivs CC BY-ND](/assets/img/by.svg)](http://creativecommons.org/licenses/by-nd/4.0/)
-[![Attribution-NoDerivs CC BY-ND](/assets/img/nd.svg)](http://creativecommons.org/licenses/by-nd/4.0/)
+[![Attribution-NoDerivs CC BY-ND]({{ site.baseurl }}/assets/img/by.svg)](http://creativecommons.org/licenses/by-nd/4.0/)
+[![Attribution-NoDerivs CC BY-ND]({{ site.baseurl }}/assets/img/nd.svg)](http://creativecommons.org/licenses/by-nd/4.0/)
 
 Attribution-NoDerivs CC BY-ND
 -----------------------------
 
 This license allows for redistribution, commercial and non-commercial, as long as it is passed along unchanged and in whole, with credit to you.
 
-[![Attribution-NonCommercial-ShareAlike](/assets/img/by.svg)](http://creativecommons.org/licenses/by-nd/4.0/)
-[![Attribution-NonCommercial-ShareAlike](/assets/img/nc-eu.svg)](http://creativecommons.org/licenses/by-nd/4.0/)
-[![Attribution-NonCommercial-ShareAlike](/assets/img/sa.svg)](http://creativecommons.org/licenses/by-nd/4.0/)
+[![Attribution-NonCommercial-ShareAlike]({{ site.baseurl }}/assets/img/by.svg)](http://creativecommons.org/licenses/by-nd/4.0/)
+[![Attribution-NonCommercial-ShareAlike]({{ site.baseurl }}/assets/img/nc-eu.svg)](http://creativecommons.org/licenses/by-nd/4.0/)
+[![Attribution-NonCommercial-ShareAlike]({{ site.baseurl }}/assets/img/sa.svg)](http://creativecommons.org/licenses/by-nd/4.0/)
 
 Attribution-NonCommercial-ShareAlike CC BY-NC-SA
 ------------------------------------------------
 
 This license lets others remix, tweak, and build upon your work non-commercially, as long as they credit you and license their new creations under the identical terms.
 
-[![Attribution-ShareAlike](/assets/img/by.svg)](http://creativecommons.org/licenses/by-sa/4.0/)
-[![Attribution-ShareAlike](/assets/img/sa.svg)](http://creativecommons.org/licenses/by-sa/4.0/)
+[![Attribution-ShareAlike]({{ site.baseurl }}/assets/img/by.svg)](http://creativecommons.org/licenses/by-sa/4.0/)
+[![Attribution-ShareAlike]({{ site.baseurl }}/assets/img/sa.svg)](http://creativecommons.org/licenses/by-sa/4.0/)
 
 Attribution-ShareAlike CC BY-SA
 -------------------------------
@@ -44,17 +44,17 @@ Attribution-ShareAlike CC BY-SA
 This license lets others remix, tweak, and build upon your work even for commercial purposes, as long as they credit you and license their new creations under the identical
 terms. This license is often compared to "copyleft" free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects.
 
-[![Attribution-NonCommercial](/assets/img/by.svg)](http://creativecommons.org/licenses/by-nc/4.0/)
-[![Attribution-NonCommercial](/assets/img/nc-eu.svg)](http://creativecommons.org/licenses/by-nc/4.0/)
+[![Attribution-NonCommercial]({{ site.baseurl }}/assets/img/by.svg)](http://creativecommons.org/licenses/by-nc/4.0/)
+[![Attribution-NonCommercial]({{ site.baseurl }}/assets/img/nc-eu.svg)](http://creativecommons.org/licenses/by-nc/4.0/)
 
 Attribution-NonCommercial CC BY-NC
 ----------------------------------
 
 This license lets others remix, tweak, and build upon your work non-commercially, and although their new works must also acknowledge you and be non-commercial, they don't have to license their derivative works on the same terms.
 
-[![Attribution-NonCommercial-NoDerivs](/assets/img/by.svg)](http://creativecommons.org/licenses/by-nc-nd/4.0/)
-[![Attribution-NonCommercial-NoDerivs](/assets/img/nd.svg)](http://creativecommons.org/licenses/by-nc-nd/4.0/)
-[![Attribution-NonCommercial-NoDerivs](/assets/img/nc-eu.svg)](http://creativecommons.org/licenses/by-nc-nd/4.0/)
+[![Attribution-NonCommercial-NoDerivs]({{ site.baseurl }}/assets/img/by.svg)](http://creativecommons.org/licenses/by-nc-nd/4.0/)
+[![Attribution-NonCommercial-NoDerivs]({{ site.baseurl }}/assets/img/nd.svg)](http://creativecommons.org/licenses/by-nc-nd/4.0/)
+[![Attribution-NonCommercial-NoDerivs]({{ site.baseurl }}/assets/img/nc-eu.svg)](http://creativecommons.org/licenses/by-nc-nd/4.0/)
 
 Attribution-NonCommercial-NoDerivs CC BY-NC-ND
 ----------------------------------------------

--- a/_includes/freebeer.md
+++ b/_includes/freebeer.md
@@ -5,7 +5,7 @@ Richard Stallman's famous quote about Free Software in contrast to Free Beer ine
 </div>
 <div class="row text-center">
     <div class="col-sm-7">
-        <img class="padded-img" src="/assets/img/freebeer/FREEBEER3.2_label.png" alt="FREE BEER (version 3.2)" />
+        <img class="padded-img" src="{{ site.baseurl }}/assets/img/freebeer/FREEBEER3.2_label.png" alt="FREE BEER (version 3.2)" />
     </div>
 </div>
 <div class="col-xs-12 visible-xs caption text-center">
@@ -36,7 +36,7 @@ Here's how the set looks like. I really dig the spoon.
 
 <div class="row text-center">
     <div class="col-sm-7">
-        <img class="padded-img" src="/assets/img/photos/setti.jpg" alt="Homebrew equipment"/>
+        <img class="padded-img" src="{{ site.baseurl }}/assets/img/photos/setti.jpg" alt="Homebrew equipment"/>
     </div>
 </div>
 <div class="col-xs-12 visible-xs caption text-center">
@@ -58,7 +58,7 @@ We started the actual brewing by grinding the various malts with the hand grinde
 
 <div class="row text-center">
     <div class="col-sm-7">
-        <img class="padded-img" src="/assets/img/photos/photo_1.jpg" alt="Grinding the various malts" />
+        <img class="padded-img" src="{{ site.baseurl }}/assets/img/photos/photo_1.jpg" alt="Grinding the various malts" />
     </div>
 </div>
 
@@ -117,7 +117,7 @@ Nonetheless, we added 90 grams of sugar into the wort and then siphoned it strai
 
 <div class="row text-center">
     <div class="col-sm-7">
-        <img class="padded-img" src="/assets/img/photos/bottling.jpg" alt="Bottling the beer" />
+        <img class="padded-img" src="{{ site.baseurl }}/assets/img/photos/bottling.jpg" alt="Bottling the beer" />
     </div>
 </div>
 <div class="col-xs-12 visible-xs caption text-center">
@@ -130,7 +130,7 @@ The bottles then remained in room temperature for nine days, the idea being that
 
 <div class="row text-center">
     <div class="col-sm-7">
-        <img class="padded-img" src="/assets/img/photos/flindat.jpg" alt="Bottles of beer" />
+        <img class="padded-img" src="{{ site.baseurl }}/assets/img/photos/flindat.jpg" alt="Bottles of beer" />
     </div>
 </div>
 <div class="col-xs-12 visible-xs caption text-center">
@@ -148,7 +148,7 @@ Then we opened some and had a taste!
 
 <div class="row text-center">
     <div class="col-sm-7">
-        <img class="padded-img" src="/assets/img/photos/tastings.jpg" alt="Beer tasting party" />
+        <img class="padded-img" src="{{ site.baseurl }}/assets/img/photos/tastings.jpg" alt="Beer tasting party" />
     </div>
 </div>
 <div class="col-xs-12 visible-xs caption text-center">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,10 +6,10 @@
 
 <title>{{ page.title }}</title>
 
-<link rel="shortcut icon" href="../../assets/ico/favicon.ico">
+<link rel="shortcut icon" href="{{ site.baseurl }}/assets/ico/favicon.ico">
 <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,700" type="text/css" />
 <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" />
-<link rel="stylesheet" href="/assets/css/css.css" />
+<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/css.css" />
 
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>

--- a/_includes/how.md
+++ b/_includes/how.md
@@ -80,7 +80,7 @@ In addition it is necessary to have someone with credibility and enthusiasm for 
 
 <div class="row text-center">
     <div class="col-sm-7">
-        <img class="padded-img" src="/assets/img/team.png" alt="Spice Program team members" />
+        <img class="padded-img" src="{{ site.baseurl }}/assets/img/team.png" alt="Spice Program team members" />
     </div>
 </div>
 <div class="col-xs-12 visible-xs caption text-center">
@@ -122,7 +122,7 @@ Our categories look like this. They haven't changed since we first defined them:
 
 <div class="row text-center">
     <div class="col-sm-7">
-        <img class="padded-img" src="/assets/img/activities.png" alt="Spice Program activities" />
+        <img class="padded-img" src="{{ site.baseurl }}/assets/img/activities.png" alt="Spice Program activities" />
     </div>
 </div>
 <div class="col-xs-12 visible-xs caption text-center">

--- a/_includes/oss-sponsorship.md
+++ b/_includes/oss-sponsorship.md
@@ -81,7 +81,7 @@ Check out this actual report by Oleg:
 
 <div class="row text-center">
     <div class="col-sm-7">
-        <img class="padded-img" src="/assets/img/contr.png" alt="Example of an open source contribution report" />
+        <img class="padded-img" src="{{ site.baseurl }}/assets/img/contr.png" alt="Example of an open source contribution report" />
     </div>
 </div>
 
@@ -90,7 +90,7 @@ We use the Flowdock tags; #contribution identifies that this is indeed a contrib
 Other considerations
 --------------------
 
-The experts in Germany and Switzerland told us it would be a good idea to create a simple one page agreement for people to sign, before they are eligible for this sponsorship. Supposedly the rationale is to get proof that people understand this is not work, but sponsorship for beneficial and strictly voluntary hobby activities. Find here a vanilla copy of [the agreement](http://www.spiceprogram.org/assets/docs/OSS-sponsorship-agreement-vanilla.odt) you can make use of. It is CC0 so you can use it without mentioning us.  
+The experts in Germany and Switzerland told us it would be a good idea to create a simple one page agreement for people to sign, before they are eligible for this sponsorship. Supposedly the rationale is to get proof that people understand this is not work, but sponsorship for beneficial and strictly voluntary hobby activities. Find here a vanilla copy of [the agreement]({{ site.baseurl }}/assets/docs/OSS-sponsorship-agreement-vanilla.odt) you can make use of. It is CC0 so you can use it without mentioning us.  
 
 Initial reception
 -----------------
@@ -99,7 +99,7 @@ Offering people money, for something they have been doing for fun, can be a [ris
 
 <div class="row text-center">
     <div class="col-sm-7">
-        <img class="padded-img" src="/assets/img/twitter.png" alt="Response to sponsoring open source contributions at twitter" />
+        <img class="padded-img" src="{{ site.baseurl }}/assets/img/twitter.png" alt="Response to sponsoring open source contributions at twitter" />
     </div>
 </div>
 
@@ -117,9 +117,9 @@ Communications
 
 Since we know Futurice company culture is of interest to some people, we will include some internal communication. 
 
-* [Initial invitation to developers](/assets/docs/invitation-quicksand.txt) (email)
-* [A few slides for the steering group](/assets/docs/mgmt-slides.odp) (ODP)
-* [The internal announcement](/assets/docs/internal-announcement.txt) (email)
+* [Initial invitation to developers]({{ site.baseurl }}/assets/docs/invitation-quicksand.txt) (email)
+* [A few slides for the steering group]({{ site.baseurl }}/assets/docs/mgmt-slides.odp) (ODP)
+* [The internal announcement]({{ site.baseurl }}/assets/docs/internal-announcement.txt) (email)
 
 Known challenges
 ----------------

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
     <body>
         <header id="topnav">
             <a href="http://www.futurice.com">
-                <img src="/assets/img/futurice-favicon.png" style="max-height: 100%;" alt="Futurice logo" />
+                <img src="{{ site.baseurl }}/assets/img/futurice-favicon.png" style="max-height: 100%;" alt="Futurice logo" />
             </a>
             <a id="menu" href="#">
                 <div class="burger">&#9776;</div>
@@ -18,29 +18,29 @@
 
             <ul class="sidebar-nav">
                 <li class="pull-right"><a href="#" id="close">&#10006;</a></li>
-                <li><a href="/">Home</a>
+                <li><a href="{{ site.baseurl }}/">Home</a>
                 </li>
-                <li><a href="/choose">Choosing a license</a>
+                <li><a href="{{ site.baseurl }}/choose">Choosing a license</a>
                 </li>
-                <li><a href="/licenses">Popular Open Source licenses</a>
+                <li><a href="{{ site.baseurl }}/licenses">Popular Open Source licenses</a>
                 </li>
-                <li><a href="/creative-commons">Creative Commons</a>
+                <li><a href="{{ site.baseurl }}/creative-commons">Creative Commons</a>
                 </li>
-                <li><a href="/history">Brief history of OSS</a>
+                <li><a href="{{ site.baseurl }}/history">Brief history of OSS</a>
                 </li>
-                <li><a href="/why">Why are we doing this?</a>
+                <li><a href="{{ site.baseurl }}/why">Why are we doing this?</a>
                 </li>
-                <li><a href="/how">How to establish a similar program?</a>
+                <li><a href="{{ site.baseurl }}/how">How to establish a similar program?</a>
                 </li>
-                <li><a href="/contracts">OSS contract terms</a>
+                <li><a href="{{ site.baseurl }}/contracts">OSS contract terms</a>
                 </li>
-                <li><a href="/summer-of-love">Summer of Love</a>
+                <li><a href="{{ site.baseurl }}/summer-of-love">Summer of Love</a>
                 </li>
-                <li><a href="/highlights">OSS Highlights</a>
+                <li><a href="{{ site.baseurl }}/highlights">OSS Highlights</a>
                 </li>
-                <li><a href="/oss-sponsorship">Sponsoring free-time Open Source</a>
+                <li><a href="{{ site.baseurl }}/oss-sponsorship">Sponsoring free-time Open Source</a>
                 </li>
-                <li><a href="/chilicorn">Realm of the Chilicorn</a>
+                <li><a href="{{ site.baseurl }}/chilicorn">Realm of the Chilicorn</a>
                 </li>
             </ul>
         </div>

--- a/assets/css/css.scss
+++ b/assets/css/css.scss
@@ -30,7 +30,7 @@ html, body {
 }
 
 .first {
-    background: transparent url('/assets/img/landing2.jpg') center center no-repeat;
+    background: transparent url('{{ site.baseurl }}/assets/img/landing2.jpg') center center no-repeat;
     -webkit-background-size: cover;
     -moz-background-size: cover;
     -o-background-size: cover;
@@ -39,15 +39,15 @@ html, body {
 }
 
 .second {
-    background: transparent url('/assets/img/ships.jpg') center center no-repeat;
+    background: transparent url('{{ site.baseurl }}/assets/img/ships.jpg') center center no-repeat;
 }
 
 .third {
-    background: transparent url('/assets/img/history.jpg') center center no-repeat;
+    background: transparent url('{{ site.baseurl }}/assets/img/history.jpg') center center no-repeat;
 }
 
 .fourth {
-    background: transparent url('/assets/img/why.jpg') center center no-repeat;
+    background: transparent url('{{ site.baseurl }}/assets/img/why.jpg') center center no-repeat;
 
 }
 
@@ -66,7 +66,7 @@ a:hover {
 }
 
 .box {
-  
+
   img {
     width: 85%;
   }
@@ -92,7 +92,7 @@ a:hover {
   }
   .orange {
     p {
-      color: #8e98a7; 
+      color: #8e98a7;
     }
 
     h3 {
@@ -438,6 +438,6 @@ footer {
   font-size: 1.2em;
   padding-top: 40px;
 }
-@media (max-width: 768px) { 
+@media (max-width: 768px) {
   h1 { font-size: 3em; }
 }

--- a/chilicorn/index.html
+++ b/chilicorn/index.html
@@ -4,7 +4,7 @@ title: Spice Program - Realm of the Chilicorn
 description: There's a program logo! And it's fabulous. Also a map of our sponsored OSS contributions.
 ---
 
-<img class="img-responsive cover-img" src="/assets/img/realm-of-the-chilicorn-midsize.png" alt="Map showing the OSS projects we have sponsored contributions to" />
+<img class="img-responsive cover-img" src="{{ site.baseurl }}/assets/img/realm-of-the-chilicorn-midsize.png" alt="Map showing the OSS projects we have sponsored contributions to" />
 
 
 <div class="container">

--- a/choose/index.html
+++ b/choose/index.html
@@ -8,7 +8,7 @@ description: How to choose the correct license for your project? Can I make use 
 
     <div class="row">
         <div class="col-md-12 centered">
-            <img src="/assets/img/choose_big.svg" style="width: 500px;" alt="Choosing a license"/>
+            <img src="{{ site.baseurl }}/assets/img/choose_big.svg" style="width: 500px;" alt="Choosing a license"/>
             <h1>Choosing a license</h1>
         </div>
         <div class="col-md-8 col-md-offset-2">

--- a/creative-commons/index.html
+++ b/creative-commons/index.html
@@ -8,7 +8,7 @@ description: What is Creative Commons? CC organization has released copyright li
 
     <div class="row">
         <div class="col-md-12 centered">
-            <img src="/assets/img/cc.svg" style="width: 500px;" alt="Creative commons" />
+            <img src="{{ site.baseurl }}/assets/img/cc.svg" style="width: 500px;" alt="Creative commons" />
             <h1>Creative commons</h1>
         </div>
         <div class="col-md-8 col-md-offset-2">
@@ -20,11 +20,11 @@ description: What is Creative Commons? CC organization has released copyright li
 <div class="container">
     <div class="row">
         <nav class="col-md-4 sidebar">
-            <a href="/creative-commons" class="licenses centered">
+            <a href="{{ site.baseurl }}/creative-commons" class="licenses centered">
                 <h3>Creative Commons</h3>
                 <p>&rarr;What is Creative Commons? How can it be used?</p>
             </a>
-            <a href="/choose" class="licenses centered">
+            <a href="{{ site.baseurl }}/choose" class="licenses centered">
                 <h3>Choosing a license</h3>
                 <p>&rarr;How to choose the best license for your work?</p>
             </a>

--- a/history/history.jade
+++ b/history/history.jade
@@ -24,19 +24,19 @@ div(style="height: 50px;")
 div.vertical
         div.choose
             div
-                a(href="/choosing")
+                a(href="{{ site.baseurl }}/choosing")
                     img(src="choose_big.svg", style="width: auto; max-width: 95%;")
                     h3 Choosing a license
                     p.box How to choose the best license for your work?
         div.common
             div
-                a(href="/licenses")
+                a(href="{{ site.baseurl }}/licenses")
                     img(src="popular.svg", style="width: auto; max-width: 95%;")
                     h3 Common open source licenses
                     p.box Check out our summaries for the 13 most common licenses.
         div.creative
             div
-                a(href="/cc")
+                a(href="{{ site.baseurl }}/cc")
                     img(src="cc.svg", style="width: auto; max-width: 95%;")
                     h3 Creative commons
                     p.box What is creative commons? How can it be used?

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ description: Spice Program is a company sponsored open source and social impact 
         <div class="row">
             <div class="col-sm-8 col-sm-offset-2" style="z-index: 1; background-color: #f3f3f4;">
                 <div class="row boxed">
-                    <a href="/why">
+                    <a href="{{ site.baseurl }}/why">
                         <div class="col-sm-10 arrow-box">
                             <h3>Why are we doing this?</h3>
                             <p>Read here why we decided to take a systematic approach to advancing open source ideology.</p>
@@ -67,19 +67,19 @@ description: Spice Program is a company sponsored open source and social impact 
             <div class="col-md-10 col-md-offset-1">
                 <div class="row highlights even">
                     <div class="col-md-4 col-sm-4 box">
-                        <a href="/freebeer">
+                        <a href="{{ site.baseurl }}/freebeer">
                             <h3>Brewing a beer</h3>
                             <p><span class="rarr">&rarr;</span> Once we stumbled upon the old Free Beer initiative, we had no choice but to brew our own derivative work.</p>
                         </a>
                     </div>
                     <div class="col-md-4 col-sm-4 box">
-                        <a href="/history">
+                        <a href="{{ site.baseurl }}/history">
                             <h3>Brief history of Open Source</h3>
                             <p><span class="rarr">&rarr;</span> Here stands a wall of text - an open source summary we wrote while we studied the subject, complemented with some shameless opinions.</p>
                         </a>
                     </div>
                     <div class="col-md-4 col-sm-4 box">
-                        <a href="/contracts">
+                        <a href="{{ site.baseurl }}/contracts">
                             <h3>OSS contract terms</h3>
                             <p><span class="rarr">&rarr;</span> We created contract terms to be able to contribute our improvements to OSS projects used in customer projects. We'll share!</p>
                         </a>
@@ -87,19 +87,19 @@ description: Spice Program is a company sponsored open source and social impact 
                 </div>
                 <div class="row highlights odd">
                     <div class="col-md-4 col-sm-4 box">
-                        <a href="/summer-of-love">
+                        <a href="{{ site.baseurl }}/summer-of-love">
                             <h3>Summer of Love</h3>
                             <p><span class="rarr">&rarr;</span> Our support system portfolio is being published as open source, for the many reasons that you'll find here.</p>
                         </a>
                     </div>
                     <div class="col-md-4 col-sm-4 box">
-                        <a href="/highlights">
+                        <a href="{{ site.baseurl }}/highlights">
                             <h3>OSS Highlights</h3>
                             <p><span class="rarr">&rarr;</span> Highlights from our Summer of Love initiative.</p>
                         </a>
                     </div>
                     <div class="col-md-4 col-sm-4 box">
-                        <a href="/oss-sponsorship">
+                        <a href="{{ site.baseurl }}/oss-sponsorship">
                             <h3>Sponsoring free-time Open Source</h3>
                             <p><span class="rarr">&rarr;</span> People practising <br/> Skills valuable at work <br/> Awesoming the world</p>
                         </a>
@@ -107,7 +107,7 @@ description: Spice Program is a company sponsored open source and social impact 
                 </div>
                 <div class="row highlights even">
                     <div class="col-md-4 col-sm-4 box">
-                        <a href="/chilicorn">
+                        <a href="{{ site.baseurl }}/chilicorn">
                             <h3>Realm of the Chilicorn</h3>
                             <p><span class="rarr">&rarr;</span> Statistics about our sponsored open source contributions.</p>
                         </a>
@@ -125,23 +125,23 @@ description: Spice Program is a company sponsored open source and social impact 
                 <p class="quote">If you work with software, you should have a basic understanding of the concepts and mechanics of free and open-source software. Start with these!</p>
             </div>
             <div class="col-sm-12">
-                <a href="/choose">
+                <a href="{{ site.baseurl }}/choose">
                     <div class="col-sm-4 box brown">
-                        <img src="/assets/img/choose_big.svg" alt="Choosing an open source license" />
+                        <img src="{{ site.baseurl }}/assets/img/choose_big.svg" alt="Choosing an open source license" />
                         <h3>Choosing a license</h3>
                         <p>How to choose the appropriate license for your project? Can you make use of someone else's work?</p>
                     </div>
                 </a>
-                <a href="/licenses">
+                <a href="{{ site.baseurl }}/licenses">
                     <div class="col-sm-4 box grey">
-                        <img src="/assets/img/popular.svg" alt="Common open source licenses" />
+                        <img src="{{ site.baseurl }}/assets/img/popular.svg" alt="Common open source licenses" />
                         <h3>Common open source licences</h3>
                         <p>Our summaries for the most common OSS licenses.</p>
                     </div>
                 </a>
-                <a href="/creative-commons">
+                <a href="{{ site.baseurl }}/creative-commons">
                     <div class="col-sm-4 box orange">
-                        <img src="/assets/img/cc.svg" alt="Creative commons" />
+                        <img src="{{ site.baseurl }}/assets/img/cc.svg" alt="Creative commons" />
                         <h3>Creative commons</h3>
                         <p>What is creative commons? How can it be used?</p>
                     </div>

--- a/licenses/index.html
+++ b/licenses/index.html
@@ -8,7 +8,7 @@ description: A list of popular and free open source licenses in a single locatio
 
     <div class="row centered">
         <div class="col-md-8 col-md-offset-2">
-            <img src="/assets/img/popular.svg" style="width: 80%;" alt="Popular and free open source licenses" />
+            <img src="{{ site.baseurl }}/assets/img/popular.svg" style="width: 80%;" alt="Popular and free open source licenses" />
             <h1>Popular and free open source licenses</h1>
         </div>
         <div class="col-md-8 col-md-offset-2">
@@ -30,11 +30,11 @@ description: A list of popular and free open source licenses in a single locatio
                 <li><a href="#BSD3-Clause">BSD 3-Clause and 2-Clause</a></li>
                 <li><a href="#MPL2">Mozilla Public License 2.0 (MPL-2)</a></li>
             </ul>
-            <a href="/creative-commons" class="licenses centered">
+            <a href="{{ site.baseurl }}/creative-commons" class="licenses centered">
                 <h3>Creative Commons</h3>
                 <p>&rarr;What is Creative Commons? How can it be used?</p>
             </a>
-            <a href="/choose" class="licenses centered">
+            <a href="{{ site.baseurl }}/choose" class="licenses centered">
                 <h3>Choosing a license</h3>
                 <p>&rarr;How to choose the best license for your work?</p>
             </a>


### PR DESCRIPTION
At the moment spiceprogram.org uses proxy to fix some urls in github pages.  By adding {{ site.baseurl }} to all urls the site is not dependent on the actual content location on the server. For example deploying to example.com/asd/spiceprogram would only require changing single variable in config.