### PR TITLE
Fix missing favicon: use chilicorn logo

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,7 @@
 
 <title>{{ page.title }}</title>
 
-<link rel="shortcut icon" href="{{ site.baseurl }}/assets/ico/favicon.ico">
+<link rel="shortcut icon" href="{{ site.baseurl }}/assets/img/logo/chilicorn_no_text-64.png">
 <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,700" type="text/css" />
 <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" />
 <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/css.css" />


### PR DESCRIPTION
This is a quick fix. A better fix would be to create cropped logos with different sizes for favicons on different platforms.