### PR TITLE
Fix typo by turning 'company sponsored' into 'company-sponsored'.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 markdown:      kramdown
-description: Spice program is a company sponsored open source and social impact program. Our goal is to make Futurice a better company and the world a better place.
+description: Spice program is a company-sponsored open source and social impact program. Our goal is to make Futurice a better company and the world a better place.
 baseurl: ""
 sass:
      style: compressed

--- a/assets/docs/invitation-quicksand.txt
+++ b/assets/docs/invitation-quicksand.txt
@@ -33,7 +33,7 @@ Let's consider a highly unlikely scenario where Jareware, as a nocturnal creatur
 tired of browsing Reddit and watching GoT re-runs. Instead he wants to contribute to some 
 OSS project, on his free time. 
 
--- If he picks one of the company sponsored projects, should he receive a compensation? 
+-- If he picks one of the company-sponsored projects, should he receive a compensation? 
 -- What kind of compensation could he receive?
 
 Have tried to come up with a reasonable suggestion; fail.

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ title: Spice Program - Futurice Social Responsibility Program
       </div>
 
       <div class="description">
-        <p class="lead">Spice is a company sponsored open source and social impact program. We make Futurice a better company and the world a better place.</p>
+        <p class="lead">Spice is a company-sponsored open source and social impact program. We make Futurice a better company and the world a better place.</p>
       </div>
     </div>
     <div class="index-activities">


### PR DESCRIPTION
 (Compound adjective.)
