### PR TITLE
Fix GH links to point to Futurice organisation

### DIFF
--- a/_includes/highlights.md
+++ b/_includes/highlights.md
@@ -9,7 +9,7 @@ Reservator is a meeting room display system for tablets. Mount your tablet next 
 
 [Summer of Love blog post](http://blog.futurice.com/reservator)
 
-[Source code](https://github.com/futurice-oss/meeting-room-tablet)
+[Source code](https://github.com/futurice/meeting-room-tablet)
 
 [Play store](https://play.google.com/store/apps/details?id=com.futurice.android.reservator)
 
@@ -24,7 +24,7 @@ Facegame is a simple game made for learning the faces and names of fellow employ
 
 [Summer of Love blog post](http://blog.futurice.com/facegame)
 
-[Source code](https://github.com/futurice-oss/facegame)
+[Source code](https://github.com/futurice/facegame)
 
 VPN Management
 --------------
@@ -37,9 +37,9 @@ VPN Management is a self-service tool for your employees to handle their OpenVPN
 
 [Summer of Love blog post](http://blog.futurice.com/vpn-management-self-provisioning-and-more)
 
-[Source code for the server](https://github.com/futurice-oss/vpn-management-server)  
+[Source code for the server](https://github.com/futurice/vpn-management-server)  
 
-[Source code for the wizard](https://github.com/futurice-oss/vpn-management-client)
+[Source code for the wizard](https://github.com/futurice/vpn-management-client)
 
 FUM
 ---
@@ -52,4 +52,4 @@ FUM is an user management system for LDAP. FUM makes it easy to handle informati
 
 [Summer of Love blog post](http://blog.futurice.com/user-friendly-web-ui-for-ldap)
 
-[Source code](https://github.com/futurice-oss/futurice-ldap-user-manager)
+[Source code](https://github.com/futurice/futurice-ldap-user-manager)

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
         {{ content }}
         <footer>
             <div class="container">
-                <p>The spiceprogram.org site is created by <a href="https://github.com/mkirvela/spice-doc-source/graphs/contributors">these people</a>.</p>
+                <p>The spiceprogram.org site is created by <a href="https://github.com/futurice/spiceprogram/graphs/contributors">these people</a>.</p>
                 <p>This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License (CC BY 4.0)</a>.</p>
                 <p>Contact: <a href="mailto:spice@futurice.com">spice@futurice.com</a></p>
             </div>


### PR DESCRIPTION
Some links pointed to old GitHub organisation that does not exist
anymore. While those have a redirect for now, they might not work in the
future. Point all the links to their current real location. As an added
bonus this saves a couple of redirects.