### PR TITLE
Bringing the sexy back

### DIFF
--- a/chilicorn/index.html
+++ b/chilicorn/index.html
@@ -4,10 +4,6 @@ title: Chilicorn - Futurice Social Responsibility Program mascot
 description: Spice Program is a company sponsored open source and social impact program. Our goal is to make Futurice a better company and the world a better place.
 ---
 
-<meta http-equiv="refresh" content="0; url=http://spiceprogram.org/chilicorn-fund/">        
-<link rel="canonical" href="http://spiceprogram.org/chilicorn-fund/" />
-
-<!--
     <div class="fullscreen-img chilicorn">&nbsp;</div>
     <div class="container content centered" style="padding-top: 200px;">
         <div class="row">
@@ -113,4 +109,3 @@ description: Spice Program is a company sponsored open source and social impact 
         </div>
       </div>
     </div>
--->


### PR DESCRIPTION
Old Chilicorn explanation page no longer needs redirect to the fund page, because we have DNS setup proper